### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,4 +15,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly
+      interval: "weekly"


### PR DESCRIPTION
Was missing a closing `"` because of too aggressive `Delete` key usage.